### PR TITLE
Added support for rewriting .Net 2 assemblies

### DIFF
--- a/MethodDecorator.Fody.Tests.Net2/MethodDecorator.Fody.Tests.Net2.csproj
+++ b/MethodDecorator.Fody.Tests.Net2/MethodDecorator.Fody.Tests.Net2.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/MethodDecorator.Fody.Tests.Net2/MethodDecorator.Fody.Tests.Net2.csproj
+++ b/MethodDecorator.Fody.Tests.Net2/MethodDecorator.Fody.Tests.Net2.csproj
@@ -7,11 +7,11 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{7EA79DF1-D3E1-4F06-9E1C-D86D14B6469F}</ProjectGuid>
+    <ProjectGuid>{4CF48B65-6DDC-45E2-8C67-2FCFB4053950}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MethodDecoratorEx.Fody.Tests</RootNamespace>
-    <AssemblyName>MethodDecoratorEx.Fody.Tests</AssemblyName>
+    <AssemblyName>MethodDecoratorEx.Fody.Tests.Net2</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -73,53 +73,49 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ClassTestsBase.cs" />
-    <Compile Include="Helpers\AssemblyExtensions.cs" />
-    <Compile Include="SimpleTestBase.cs" />
-    <Compile Include="TestsBase.cs" />
-    <Compile Include="Method.cs" />
-    <Compile Include="Helpers\StaticMembersDynamicWrapper.cs" />
-    <Compile Include="Helpers\VersionReader.cs" />
-    <Compile Include="Helpers\WeaverHelper.cs" />
-    <Compile Include="Helpers\TestAssemblyResolver.cs" />
-    <Compile Include="WhenAsync.cs" />
-    <Compile Include="WhenDecoratedByNoInit.cs" />
-    <Compile Include="WhenDecoratedInderectlly.cs" />
-    <Compile Include="WhenDecoratingAbstractMethods.cs" />
-    <Compile Include="DecoratingConstructors.cs">
-      <SubType>Code</SubType>
+    <Compile Include="..\MethodDecorator.Fody.Tests\Helpers\AssemblyExtensions.cs">
+      <Link>Helpers\AssemblyExtensions.cs</Link>
     </Compile>
-    <Compile Include="WhenDecoratingByDerivedFromInterface.cs" />
-    <Compile Include="WhenDecoratingByDerivedInterceptor.cs" />
-    <Compile Include="WhenDecoratingExtensionMethods.cs" />
-    <Compile Include="WhenDecoratingGenericMethods.cs" />
-    <Compile Include="WhenDecoratingGenericTypes.cs" />
-    <Compile Include="WhenDecoratingMethodsWithReturnValues.cs" />
-    <Compile Include="WhenDecoratingPropertyMethods.cs" />
-    <Compile Include="WhenDecoratingByExternalInterceptor.cs" />
-    <Compile Include="WhenDecoratingVoidMethod.cs" />
-    <Compile Include="WhenInterceptingNestedTypes.cs" />
-    <Compile Include="Helpers\XmlExtensions.cs" />
+    <Compile Include="..\MethodDecorator.Fody.Tests\Helpers\StaticMembersDynamicWrapper.cs">
+      <Link>Helpers\StaticMembersDynamicWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\MethodDecorator.Fody.Tests\Helpers\TestAssemblyResolver.cs">
+      <Link>Helpers\TestAssemblyResolver.cs</Link>
+    </Compile>
+    <Compile Include="..\MethodDecorator.Fody.Tests\Helpers\VersionReader.cs">
+      <Link>Helpers\VersionReader.cs</Link>
+    </Compile>
+    <Compile Include="..\MethodDecorator.Fody.Tests\Helpers\WeaverHelper.cs">
+      <Link>Helpers\WeaverHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\MethodDecorator.Fody.Tests\Helpers\XmlExtensions.cs">
+      <Link>Helpers\XmlExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\MethodDecorator.Fody.Tests\Method.cs">
+      <Link>Method.cs</Link>
+    </Compile>
+    <Compile Include="..\MethodDecorator.Fody.Tests\TestsBase.cs">
+      <Link>TestsBase.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimpleTestBase.cs" />
+    <Compile Include="WhenDecoratingNet2Methods.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MethodDecorator.Fody\MethodDecorator.Fody.csproj">
-      <Project>{3B17CFD4-10E7-42DB-88D6-A10680B0BFBE}</Project>
-      <Name>MethodDecoratorEx.Fody</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\MethodDecoratorInterfaces\MethodDecoratorInterfaces.csproj">
-      <Project>{44088df4-081e-45f6-bede-fe33054e8cbd}</Project>
-      <Name>MethodDecoratorInterfaces</Name>
+      <Project>{3b17cfd4-10e7-42db-88d6-a10680b0bfbe}</Project>
+      <Name>MethodDecorator.Fody</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!--<Import Project="$(SolutionDir)Tools\Pepita\PepitaGet.targets" />-->
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/MethodDecorator.Fody.Tests.Net2/Properties/AssemblyInfo.cs
+++ b/MethodDecorator.Fody.Tests.Net2/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MethodDecorator.Fody.Tests.Net2")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MethodDecorator.Fody.Tests.Net2")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4cf48b65-6ddc-45e2-8c67-2fcfb4053950")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MethodDecorator.Fody.Tests.Net2/SimpleTestBase.cs
+++ b/MethodDecorator.Fody.Tests.Net2/SimpleTestBase.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+using MethodDecorator.Fody.Tests;
+
+namespace MethodDecoratorEx.Fody.Tests
+{
+    public class SimpleTestBase : TestsBase {
+        private static readonly Assembly _assembly = CreateAssembly();
+
+        public SimpleTestBase() {
+            _assembly.GetStaticInstance("SimpleTest.Net2.TestRecords").Clear();
+        }
+
+        protected override Assembly Assembly {
+            get { return _assembly; }
+        }
+
+        protected override dynamic RecordHost {
+            get { return this.Assembly.GetStaticInstance("SimpleTest.Net2.TestRecords"); }
+        }
+
+        private static Assembly CreateAssembly() {
+            var weaverHelper = new WeaverHelper(@"SimpleTest.Net2\SimpleTest.Net2.csproj");
+            return weaverHelper.Weave();
+        }
+    }
+}

--- a/MethodDecorator.Fody.Tests.Net2/WhenDecoratingNet2Methods.cs
+++ b/MethodDecorator.Fody.Tests.Net2/WhenDecoratingNet2Methods.cs
@@ -1,0 +1,19 @@
+﻿using MethodDecorator.Fody.Tests;
+using Xunit;
+
+namespace MethodDecoratorEx.Fody.Tests
+{
+    public class WhenDecoratingNet2Methods : SimpleTestBase {
+
+        [Fact]
+        public void ShouldReportOnEntryAndExit() {
+            dynamic testClass = Assembly.GetInstance("SimpleTest.Net2.InterceptingMethods");
+            Assert.NotNull(testClass);
+
+            int value = testClass.ReturnsNumber();
+
+            this.CheckInit("SimpleTest.Net2.InterceptingMethods", "SimpleTest.Net2.InterceptingMethods.ReturnsNumber");
+            this.CheckMethodSeq(new[] { Method.Init, Method.OnEnter, Method.Body, Method.OnExit });
+        }
+    }
+}

--- a/MethodDecorator.Fody.Tests.Net2/packages.config
+++ b/MethodDecorator.Fody.Tests.Net2/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net451" />
+  <package id="xunit" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net451" />
+</packages>

--- a/MethodDecorator.Fody.Tests/TestsBase.cs
+++ b/MethodDecorator.Fody.Tests/TestsBase.cs
@@ -16,8 +16,13 @@ namespace MethodDecoratorEx.Fody.Tests {
 
         protected IList<Tuple<Method, object[]>> Records {
             get {
+#if NET2
                 var records = (IList<object[]>)this.RecordHost.Records;
                 return records.Select(x => new Tuple<Method, object[]>((Method)x[0], (object[])x[1])).ToList();
+#else
+                var records = (IList<Tuple<int, object[]>>)this.RecordHost.Records;
+                return records.Select(x => new Tuple<Method, object[]>((Method)x.Item1, x.Item2)).ToList();
+#endif
             }
         }
 
@@ -25,7 +30,7 @@ namespace MethodDecoratorEx.Fody.Tests {
             // almost global lock to prevent parrllel test run because we use static (
             Monitor.Enter(_sync);
         }
-        
+
         protected void CheckMethodSeq(Method[] methods) {
             var coll = this.Records.Select(x => x.Item1).ToArray();
             Assert.Equal(methods, coll);

--- a/MethodDecorator.Fody.Tests/TestsBase.cs
+++ b/MethodDecorator.Fody.Tests/TestsBase.cs
@@ -16,8 +16,8 @@ namespace MethodDecoratorEx.Fody.Tests {
 
         protected IList<Tuple<Method, object[]>> Records {
             get {
-                var records = (IList<Tuple<int, object[]>>)this.RecordHost.Records;
-                return records.Select(x => new Tuple<Method, object[]>((Method)x.Item1, x.Item2)).ToList();
+                var records = (IList<object[]>)this.RecordHost.Records;
+                return records.Select(x => new Tuple<Method, object[]>((Method)x[0], (object[])x[1])).ToList();
             }
         }
 

--- a/MethodDecorator.Fody.sln
+++ b/MethodDecorator.Fody.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MethodDecorator.Fody", "MethodDecorator.Fody\MethodDecorator.Fody.csproj", "{3B17CFD4-10E7-42DB-88D6-A10680B0BFBE}"
 EndProject
@@ -24,7 +24,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		uninstall.ps1 = uninstall.ps1
 	EndProjectSection
 EndProject
-
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleTest.Net2", "TestAssemblies\SimpleTest.Net2\SimpleTest.Net2.csproj", "{68174FE4-263F-42B4-BB1F-86D77782E396}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MethodDecorator.Fody.Tests.Net2", "MethodDecorator.Fody.Tests.Net2\MethodDecorator.Fody.Tests.Net2.csproj", "{4CF48B65-6DDC-45E2-8C67-2FCFB4053950}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +54,14 @@ Global
 		{44088DF4-081E-45F6-BEDE-FE33054E8CBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44088DF4-081E-45F6-BEDE-FE33054E8CBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44088DF4-081E-45F6-BEDE-FE33054E8CBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68174FE4-263F-42B4-BB1F-86D77782E396}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68174FE4-263F-42B4-BB1F-86D77782E396}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68174FE4-263F-42B4-BB1F-86D77782E396}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68174FE4-263F-42B4-BB1F-86D77782E396}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CF48B65-6DDC-45E2-8C67-2FCFB4053950}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CF48B65-6DDC-45E2-8C67-2FCFB4053950}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CF48B65-6DDC-45E2-8C67-2FCFB4053950}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CF48B65-6DDC-45E2-8C67-2FCFB4053950}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -58,5 +69,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{A47D69DD-74D6-466F-9A4E-DD0D09BB1E93} = {274A2E6A-5B50-4D24-862E-86C05F8D89C4}
 		{1D38DEB2-204D-4DBE-BB03-0FA14F79F5A4} = {274A2E6A-5B50-4D24-862E-86C05F8D89C4}
+		{68174FE4-263F-42B4-BB1F-86D77782E396} = {274A2E6A-5B50-4D24-862E-86C05F8D89C4}
 	EndGlobalSection
 EndGlobal

--- a/MethodDecorator.Fody/MethodDecorator.cs
+++ b/MethodDecorator.Fody/MethodDecorator.cs
@@ -18,12 +18,12 @@ namespace MethodDecoratorEx.Fody {
 
         public void Decorate(TypeDefinition type, MethodDefinition method, CustomAttribute attribute) {
             method.Body.InitLocals = true;
-
+            
             var methodBaseTypeRef = this._referenceFinder.GetTypeReference(typeof(MethodBase));
 
             var exceptionTypeRef = this._referenceFinder.GetTypeReference(typeof(Exception));
             var parameterTypeRef = this._referenceFinder.GetTypeReference(typeof(object));
-            var parametersArrayTypeRef = this._referenceFinder.GetTypeReference(typeof(object[]));
+            var parametersArrayTypeRef = new ArrayType(parameterTypeRef);
 
             var methodVariableDefinition = AddVariableDefinition(method, "__fody$method", methodBaseTypeRef);
             var attributeVariableDefinition = AddVariableDefinition(method, "__fody$attribute", attribute.AttributeType);

--- a/MethodDecorator.Fody/TypeReferenceExtensions.cs
+++ b/MethodDecorator.Fody/TypeReferenceExtensions.cs
@@ -7,9 +7,6 @@ using Mono.Cecil;
 
 namespace MethodDecoratorEx.Fody {
     public static class TypeReferenceExtensions {
-        public static bool Implements<T>(this TypeDefinition typeDefinition) {
-            return typeDefinition.Implements(typeof(T));
-        }
 
         public static bool Implements(this TypeDefinition typeDefinition, System.Type type) {
             if (type.IsInterface == false) {
@@ -31,16 +28,6 @@ namespace MethodDecoratorEx.Fody {
             }
 
             return false;
-        }
-
-        public static bool DerivesFrom<T>(this TypeDefinition typeDefinition) {
-            return typeDefinition.DerivesFrom(typeof(T));
-        }
-
-        public static bool DerivesFrom(this TypeDefinition typeDefinition, System.Type type) {
-            var referenceFinder = new ReferenceFinder(typeDefinition.Module);
-            var baseTypeDefinition = referenceFinder.GetTypeReference(type);
-            return typeDefinition.DerivesFrom(baseTypeDefinition);
         }
 
         public static bool DerivesFrom(this TypeReference typeReference, TypeReference expectedBaseTypeReference) {

--- a/TestAssemblies/SimpleTest.Net2/InterceptingMethods.cs
+++ b/TestAssemblies/SimpleTest.Net2/InterceptingMethods.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+
+namespace SimpleTest.Net2
+{
+    public class InterceptingMethods {
+        int finallyCalled;
+
+        [Interceptor]
+        public int ReturnsNumber() {
+            try
+            {
+                using (var fs = new MemoryStream())
+                {
+                    TestRecords.RecordBody("ReturnsNumber");
+                    return 42;
+                }
+            }
+            catch(Exception)
+            {
+                // do nothing
+                return 40;
+            }
+            finally
+            {
+                IncrementFinally();
+            }
+        }
+
+        private void IncrementFinally()
+        {
+            finallyCalled += 1;
+        }
+    }
+}

--- a/TestAssemblies/SimpleTest.Net2/InterceptorAttribute.cs
+++ b/TestAssemblies/SimpleTest.Net2/InterceptorAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reflection;
+
+namespace SimpleTest.Net2
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Assembly | AttributeTargets.Module)]
+    internal class InterceptorAttribute : Attribute
+    {
+        public void Init(object instance, MethodBase method, object[] args)
+        {
+            if (null == method) throw new ArgumentNullException("method");
+            TestRecords.RecordInit(instance, method.DeclaringType.FullName + "." + method.Name, args.Length);
+        }
+        public void OnEntry()
+        {
+            TestRecords.RecordOnEntry();
+        }
+
+        public void OnExit()
+        {
+            TestRecords.RecordOnExit();
+        }
+
+        public void OnException(Exception exception)
+        {
+            TestRecords.RecordOnException(exception.GetType(), exception.Message);
+        }
+    }
+}

--- a/TestAssemblies/SimpleTest.Net2/Properties/AssemblyInfo.cs
+++ b/TestAssemblies/SimpleTest.Net2/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+using SimpleTest.Net2;
+
+[assembly: AssemblyTitle("SimpleTest.Net2")]
+
+[module: Interceptor]
+

--- a/TestAssemblies/SimpleTest.Net2/SimpleTest.Net2.csproj
+++ b/TestAssemblies/SimpleTest.Net2/SimpleTest.Net2.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/TestAssemblies/SimpleTest.Net2/SimpleTest.Net2.csproj
+++ b/TestAssemblies/SimpleTest.Net2/SimpleTest.Net2.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{68174FE4-263F-42B4-BB1F-86D77782E396}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SimpleTest.Net2</RootNamespace>
+    <AssemblyName>SimpleTest.Net2</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="InterceptingMethods.cs" />
+    <Compile Include="InterceptorAttribute.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestRecords.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/TestAssemblies/SimpleTest.Net2/TestRecords.cs
+++ b/TestAssemblies/SimpleTest.Net2/TestRecords.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace SimpleTest {
+namespace SimpleTest.Net2 {
     public enum Method {
         Init = 0,
         OnEnter = 1,

--- a/TestAssemblies/SimpleTest/AsyncClass.cs
+++ b/TestAssemblies/SimpleTest/AsyncClass.cs
@@ -5,17 +5,17 @@ namespace SimpleTest {
     public class AsyncClass {
         [Interceptor]
         public async Task SimpleAsyncMethod() {
-            await Task.Delay(1);
+            await Task.Delay(1).ConfigureAwait(false);
         }
 
         [Interceptor]
         public async Task<int> SimpleAsyncMethodWithResult() {
-            return await Task.FromResult(1);
+            return await Task.FromResult(1).ConfigureAwait(false);
         }
 
         [Interceptor]
         public async Task<int> SimpleAsyncMethodWithException() {
-            var res = await Task.FromResult(1);
+            var res = await Task.FromResult(1).ConfigureAwait(false);
             throw new Exception("123");
             return res;
         }

--- a/TestAssemblies/SimpleTest/AsyncClass.cs
+++ b/TestAssemblies/SimpleTest/AsyncClass.cs
@@ -10,12 +10,12 @@ namespace SimpleTest {
 
         [Interceptor]
         public async Task<int> SimpleAsyncMethodWithResult() {
-            return await Task.FromResult(1).ConfigureAwait(false);
+            return await Task.FromResult(1);
         }
 
         [Interceptor]
         public async Task<int> SimpleAsyncMethodWithException() {
-            var res = await Task.FromResult(1).ConfigureAwait(false);
+            var res = await Task.FromResult(1);
             throw new Exception("123");
             return res;
         }

--- a/TestAssemblies/SimpleTest/TestRecords.cs
+++ b/TestAssemblies/SimpleTest/TestRecords.cs
@@ -12,7 +12,11 @@ namespace SimpleTest {
     }
 
     public static class TestRecords {
+#if NET2
         private static readonly IList<object[]> _records = new List<object[]>();
+#else
+        private static readonly IList<Tuple<int, object[]>> _records = new List<Tuple<int, object[]>>();
+#endif
 
         public static void Clear() {
             _records.Clear();
@@ -37,13 +41,20 @@ namespace SimpleTest {
         public static void RecordBody(string name, string extraInfo = null) {
             Record(Method.Body, new object[] { name, extraInfo });
         }
-
+#if NET2
         internal static void Record(Method method, object[] args = null) {
             _records.Add(new object[] { (int)method, args });
         }
 
         public static IList<object[]> Records => _records;
+#else
+        internal static void Record(Method method, object[] args = null)
+        {
+            _records.Add(Tuple.Create((int)method, args));
+        }
 
+        public static IList<Tuple<int, object[]>> Records => _records;
+#endif
         public static void RecordOnContinuation() {
             Record(Method.OnContinuation);
         }


### PR DESCRIPTION
Added support for rewriting .Net 2 assemblies without adding a reference to mscorlib 4.0.0.0  (see issue Fody/MethodDecorator#36).