### PR TITLE
Provide instance reference for constructor calls.

### DIFF
--- a/MethodDecorator.Fody/MethodProcessor.cs
+++ b/MethodDecorator.Fody/MethodProcessor.cs
@@ -365,7 +365,7 @@ public partial class ModuleWeaver
         if (initMethodRef.Parameters.Count > 1)
         {
             // then push the instance reference onto the stack
-            if (memberDefinition.IsConstructor || memberDefinition.IsStatic)
+            if (memberDefinition.IsStatic)
             {
                 list.Add(processor.Create(OpCodes.Ldnull));
             }


### PR DESCRIPTION
#### Description

`instance` parameter in the `IMethodDecorator.Init` method is currently `null` for constructor calls.
As described in https://github.com/Fody/MethodDecorator/issues/71 , it can be useful to have a reference to the instance.

#### The solution

The PR provides the instance reference for constructors. Now the only time the reference is not provided is for static members.

One caveat with this is that the object is only fully initialized after the constructor has finished, so providing the reference could cause issues if it's used for operations that require a fully initialized object.

#### Todos

 * [ ] Related issues - https://github.com/Fody/MethodDecorator/issues/71
 * [ ] Tests
 * [ ] Documentation